### PR TITLE
Allow token authn for OCCI probe

### DIFF
--- a/lib/nagios/promoo/occi/master.rb
+++ b/lib/nagios/promoo/occi/master.rb
@@ -23,7 +23,7 @@ class Nagios::Promoo::Occi::Master < ::Thor
   end
 
   class_option :endpoint, type: :string, desc: 'OCCI-enabled endpoint', default: 'http://localhost:3000/'
-  class_option :auth, type: :string, desc: 'Authentication mechanism', enum: %w(x509-voms), default: 'x509-voms'
+  class_option :auth, type: :string, desc: 'Authentication mechanism', enum: %w(x509-voms token), default: 'x509-voms'
   class_option :token, type: :string, desc: 'Authentication token', default: "file:///tmp/x509up_u#{`id -u`.strip}"
 
   available_probes.each do |probe|

--- a/lib/nagios/promoo/occi/probes/base_probe.rb
+++ b/lib/nagios/promoo/occi/probes/base_probe.rb
@@ -16,6 +16,7 @@ class Nagios::Promoo::Occi::Probes::BaseProbe
         :type               => options[:auth].gsub('-voms', ''),
         :user_cert          => options[:token].gsub('file://', ''),
         :user_cert_password => nil,
+        :token              => options[:token],
         :ca_path            => options[:ca_path],
         :voms               => options[:auth] == 'x509-voms' ? true : false
       },


### PR DESCRIPTION
Just add the new authn type and re-use the --token argument.