### PR TITLE
Use AppID instead of mpuri for searching in AppDB

### DIFF
--- a/lib/nagios/promoo/occi/probes/compute_probe.rb
+++ b/lib/nagios/promoo/occi/probes/compute_probe.rb
@@ -16,7 +16,15 @@ module Nagios
 
             def options
               [
-                [:mpuri, { type: :string, required: true, desc: 'AppDB MPURI referencing a virtual appliance' }],
+                [:appid, { type: :string, required: true, desc: 'AppDB ID referencing a virtual appliance' }],
+                [
+                  :vo,
+                  {
+                    type: :string,
+                    required: true,
+                    desc: 'Virtual Organization name (used to select the appropriate template)'
+                  }
+                ],
                 [
                   :with_storage,
                   {
@@ -174,14 +182,14 @@ module Nagios
 
           def appdb_appliance
             appliances = [appdb_provider['provider:image']].flatten.compact
-            appliances.delete_if { |appl| appl['mp_uri'].blank? }
+            appliances.delete_if { |appl| appl['appid'].blank? }
 
             appliance = appliances.detect do |appl|
-              normalize_mpuri(appl['mp_uri']) == normalize_mpuri(options[:mpuri])
+              appl['appid'] == options[:appid] and appl['voname'] == options[:vo]
             end
             if appliance.blank?
-              raise 'Site does not have an appliance with MPURI '\
-                   "#{normalize_mpuri(options[:mpuri]).inspect} published in AppDB"
+              raise 'Site does not have an appliance with AppID '\
+                   "#{options[:appid]} published in AppDB for VO #{options[:vo]}"
             end
 
             appliance['va_provider_image_id'].split('#').last


### PR DESCRIPTION
This changes the command line of the occi probe to use appid and VO instead of the mpuri. 
AppID does not change if the image is updated and allows to locate a VA even if the site does not have the latest version.

Probe should be invoked now as follows:
```
nagios-promoo occi compute --appid=1017  --vo ops \
                           --endpoint $OCCI_URL
```